### PR TITLE
fix ANSI C code generation

### DIFF
--- a/src/gencode.cpp
+++ b/src/gencode.cpp
@@ -147,21 +147,21 @@ static void comp_fir()
 
 static void comp_iir()
 {
-	printf("#define NZEROS %d\n", nzeros);
-	printf("#define NPOLES %d\n", npoles);
-	printf("#define GAIN   %15.9e\n\n", pbgain);
-	printf("static float xv[NZEROS+1], yv[NPOLES+1];\n\n");
+	printf("static float filterloop(float next_input_value)\n");
+	printf("{\n");
+	printf("    const int NZEROS = %d;\n", nzeros);
+	printf("    const int NPOLES = %d;\n", npoles);
+	printf("    const float GAIN = %15.9e;\n\n", pbgain);
+	printf("    static float xv[NZEROS+1], yv[NPOLES+1];\n\n");
 	margin = 20;
-	printf("static void filterloop()\n");
-	printf("  { for (;;)\n");
-	printf("      { "); pr_shiftdown("xv", nzeros); putchar('\n');
-	printf("        xv[%d] = `next input value' / GAIN;\n", nzeros);
-	printf("        "); pr_shiftdown("yv", npoles); putchar('\n');
-	printf("        yv[%d] =", npoles);
+	printf("    "); pr_shiftdown("xv", nzeros); putchar('\n');
+	printf("    xv[%d] = next_input_value / GAIN;\n", nzeros);
+	printf("    "); pr_shiftdown("yv", npoles); putchar('\n');
+	printf("    yv[%d] =", npoles);
 	pr_xpart("xv"); pr_ypart("yv"); printf(";\n");
-	printf("        `next output value' = yv[%d];\n", npoles);
-	printf("      }\n");
-	printf("  }\n\n");
+	printf("    return yv[%d];\n", npoles);
+
+	printf("}\n\n");
 }
 
 


### PR DESCRIPTION
This tool helped me a lot. But the generated ANSI C code is like this:
```
/* Digital filter designed by mkfilter/mkshape/gencode   A.J. Fisher
   Command line: /www/usr/fisher/helpers/mkfilter -Bu -Lp -o 4 -a 8.0000000000e-02 0.0000000000e+00 -l */

#define NZEROS 4
#define NPOLES 4
#define GAIN   4.474489752e+02

static float xv[NZEROS+1], yv[NPOLES+1];

static void filterloop()
  { for (;;)
      { xv[0] = xv[1]; xv[1] = xv[2]; xv[2] = xv[3]; xv[3] = xv[4]; 
        xv[4] = next input value / GAIN;
        yv[0] = yv[1]; yv[1] = yv[2]; yv[2] = yv[3]; yv[3] = yv[4]; 
        yv[4] =   (xv[0] + xv[4]) + 4 * (xv[1] + xv[3]) + 6 * xv[2]
                     + ( -0.2644548164 * yv[0]) + (  1.4034846714 * yv[1])
                     + ( -2.8673991091 * yv[2]) + (  2.6926109870 * yv[3]);
        next output value = yv[4];
      }
  }
```
which is not compilable. I edited the ANSI C generator and the code is like this:
```
/* Digital filter designed by mkfilter/mkshape/gencode   A.J. Fisher
   Command line: ./mkfilter -Bu -Lp -o 4 -a 8.0000000000e-02 0.0000000000e+00 -l */

static float filterloop(float next_input_value)
{
    const int NZEROS = 4;
    const int NPOLES = 4;
    const float GAIN = 4.474489752e+02;

    static float xv[NZEROS+1], yv[NPOLES+1];

    xv[0] = xv[1]; xv[1] = xv[2]; xv[2] = xv[3]; xv[3] = xv[4]; 
    xv[4] = next_input_value / GAIN;
    yv[0] = yv[1]; yv[1] = yv[2]; yv[2] = yv[3]; yv[3] = yv[4]; 
    yv[4] =   (xv[0] + xv[4]) + 4 * (xv[1] + xv[3]) + 6 * xv[2]
                     + ( -0.2644548164 * yv[0]) + (  1.4034846714 * yv[1])
                     + ( -2.8673991091 * yv[2]) + (  2.6926109870 * yv[3]);
    return yv[4];
}
```